### PR TITLE
Added strategy pattern for payment providers

### DIFF
--- a/src/controller/lnurlController.ts
+++ b/src/controller/lnurlController.ts
@@ -1,11 +1,10 @@
 import { NextFunction, Request, Response } from "express";
+import { nip19 } from "nostr-tools";
 
 import { User } from ".././models/user";
 import { parseInvoice } from ".././utils/lightning";
-import { createInvoice } from ".././utils/blink";
 import { Transaction } from ".././models/transaction";
-import { wallet } from "..";
-import { nip19 } from "nostr-tools";
+import { lnProvider, wallet } from "..";
 
 const metadata = "A cashu lightning address! Neat!";
 
@@ -51,7 +50,10 @@ export async function lnurlController(
   );
   const { amount: mintAmount } = parseInvoice(mintPr);
   try {
-    const invoiceRes = await createInvoice(mintAmount / 1000, "Cashu Address");
+    const invoiceRes = await lnProvider.createInvoice(
+      mintAmount / 1000,
+      "Cashu Address",
+    );
     await Transaction.createTransaction(
       mintPr,
       mintHash,

--- a/src/controller/paidController.ts
+++ b/src/controller/paidController.ts
@@ -1,7 +1,6 @@
 import { Request, Response } from "express";
 import { Transaction } from "../models/transaction";
-import { sendPayment } from "../utils/blink";
-import { wallet } from "..";
+import { lnProvider, wallet } from "..";
 import { Claim } from "../models/claim";
 
 export async function paidController(
@@ -25,11 +24,10 @@ export async function paidController(
     const newAmount =
       Number(transaction.settlementAmount) -
       Math.floor(Math.max(Number(transaction.settlementAmount) / 100, 1));
-    console.log(newAmount);
     const reqHash = transaction.initiationVia.paymentHash;
     const internalTx = await Transaction.getTransactionByHash(reqHash);
     try {
-      await sendPayment(internalTx.mint_pr);
+      await lnProvider.payInvoice(internalTx.mint_pr);
     } catch (e) {
       // TO-DO log failed payment and retry
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,8 +3,12 @@ import bodyparser from "body-parser";
 import cors from "cors";
 import { CashuMint, CashuWallet } from "@cashu/cashu-ts";
 import routes from "./routes";
+import { LightningHandler } from "./utils/lightning";
+import { BlinkProvider } from "./utils/blink";
 
 export const wallet = new CashuWallet(new CashuMint(process.env.MINTURL!));
+export const lnProvider = new LightningHandler(new BlinkProvider());
+
 const app = express();
 
 app.use(bodyparser.json());

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -8,6 +8,23 @@ declare global {
   }
 }
 
+export interface PaymentProvider {
+  createInvoice: (
+    amount: number,
+    memo?: string,
+  ) => Promise<{
+    paymentRequest: string;
+    paymentHash: string;
+    paymentSecret: string;
+  }>;
+  payInvoice: (invoice: string) => Promise<PaymentResponse>;
+  checkPayment: (invoice: string) => Promise<{ paid: boolean }>;
+}
+
+type PaymentResponse<TStatus = boolean> = TStatus extends true
+  ? { paid: TStatus; preimage: string }
+  : { paid: TStatus };
+
 export type AuthData =
   | { authorized: false }
   | { authorized: true; data: { pubkey: string; npub: string } };
@@ -37,32 +54,6 @@ export type LNBitsInvoiceResponse = {
   payment_request: string;
   checking_id: string;
   lnurl_response?: string;
-};
-
-export type BlinkInvoiceResponse = {
-  lnInvoiceCreateOnBehalfOfRecipient: {
-    invoice: {
-      paymentRequest: string;
-      paymentHash: string;
-      paymentSecret: string;
-      satoshis: number;
-    };
-  };
-};
-
-export type BlinkPaymentResponse = {
-  lnInvoicePaymentSend: {
-    status: string;
-  };
-};
-
-export type BlinkStatusReponse = {
-  lnInvoicePaymentStatus: {
-    status: "PAID" | "PENDING" | "EXPIRED";
-    errors?: {
-      message: string;
-    };
-  };
 };
 
 export interface PaymentJWTPayload extends JwtPayload {

--- a/src/utils/lightning.ts
+++ b/src/utils/lightning.ts
@@ -1,7 +1,9 @@
 import { decode } from "light-bolt11-decoder";
+import { PaymentProvider } from "../types";
 
 type InvoiceData = {
   amount: number;
+  paymentHash: string;
   memo?: string;
 };
 
@@ -15,6 +17,25 @@ export function parseInvoice(invoice: string): InvoiceData {
     if (sections[i].name === "description") {
       invoiceData.memo = sections[i].value;
     }
+    if (sections[i].name === "payment_hash") {
+      invoiceData.paymentHash = sections[i].value;
+    }
   }
   return invoiceData;
+}
+
+export class LightningHandler {
+  provider: PaymentProvider;
+  constructor(provider: PaymentProvider) {
+    this.provider = provider;
+  }
+  async createInvoice(amount: number, memo?: string) {
+    return this.provider.createInvoice(amount, memo);
+  }
+  async payInvoice(invoice: string) {
+    return this.provider.payInvoice(invoice);
+  }
+  async checkPayment(invoice: string) {
+    return this.provider.checkPayment(invoice);
+  }
 }


### PR DESCRIPTION
- Removed hardcoded payment logic
- Added a LightningHandler class that takes in a Payment Provider Instance
- Payment Provider Instances have to implement an interface

This allows us to add different payment providers along the go, without having to touch business logic. Simply add the Provider Class as module and switch out the Provider Instance in index.ts