### PR TITLE
New Claim Model + Database cleaner

### DIFF
--- a/src/controller/claimController.ts
+++ b/src/controller/claimController.ts
@@ -1,6 +1,6 @@
 import { NextFunction, Request, Response } from "express";
 import { verifyAuth } from "../utils/auth";
-import { CashuMint, getEncodedToken } from "@cashu/cashu-ts";
+import { CashuMint, Proof, getEncodedToken } from "@cashu/cashu-ts";
 import { Claim, User } from "../models";
 
 export async function balanceController(
@@ -32,14 +32,23 @@ export async function balanceController(
     const npubClaims = await Claim.getUserClaims(isAuth.data.npub);
     allClaims = npubClaims;
   }
-  const proofs = allClaims.map((claim) => claim.proofs).flat();
+  const proofs = allClaims.map((claim) => claim.proof);
   const payload = {
     proofs: proofs.map((p) => ({ secret: p.secret })),
   };
   const { spendable } = await new CashuMint(process.env.MINTURL!).check(
     payload,
   );
-  const spendableProofs = proofs.filter((_, i) => spendable[i]);
+  const spendableProofs: Proof[] = [];
+  const unspendableClaims: Claim[] = [];
+  for (let i = 0; i < proofs.length; i++) {
+    if (spendable[i]) {
+      spendableProofs.push(proofs[i]);
+    } else {
+      unspendableClaims.push(allClaims[i]);
+    }
+  }
+
   const balance = spendableProofs.reduce((a, c) => a + c.amount, 0);
   return res.json({ error: false, data: balance });
 }
@@ -72,7 +81,7 @@ export async function claimGetController(
   } else {
     allClaims = await Claim.getUserClaims(isAuth.data.npub);
   }
-  const proofs = allClaims.map((claim) => claim.proofs).flat();
+  const proofs = allClaims.map((claim) => claim.proof);
   const payload = { proofs: proofs.map((p) => ({ secret: p.secret })) };
   const { spendable } = await new CashuMint(process.env.MINTURL!).check(
     payload,

--- a/src/controller/claimController.ts
+++ b/src/controller/claimController.ts
@@ -48,7 +48,10 @@ export async function balanceController(
       unspendableClaims.push(allClaims[i]);
     }
   }
-
+  Claim.updateClaimsStatus(
+    unspendableClaims.map((claim) => claim.id),
+    "spent",
+  );
   const balance = spendableProofs.reduce((a, c) => a + c.amount, 0);
   return res.json({ error: false, data: balance });
 }

--- a/src/controller/claimController.ts
+++ b/src/controller/claimController.ts
@@ -25,11 +25,11 @@ export async function balanceController(
   const user = await User.getUserByPubkey(isAuth.data.pubkey);
   let allClaims: Claim[];
   if (user) {
-    const userClaims = await Claim.getUserClaims(user.name);
-    const npubClaims = await Claim.getUserClaims(isAuth.data.npub);
+    const userClaims = await Claim.getUserReadyClaims(user.name);
+    const npubClaims = await Claim.getUserReadyClaims(isAuth.data.npub);
     allClaims = [...userClaims, ...npubClaims];
   } else {
-    const npubClaims = await Claim.getUserClaims(isAuth.data.npub);
+    const npubClaims = await Claim.getUserReadyClaims(isAuth.data.npub);
     allClaims = npubClaims;
   }
   const proofs = allClaims.map((claim) => claim.proof);
@@ -78,11 +78,11 @@ export async function claimGetController(
   const user = await User.getUserByPubkey(isAuth.data.pubkey);
   let allClaims: Claim[];
   if (user) {
-    const userClaims = await Claim.getUserClaims(user.name);
-    const npubClaims = await Claim.getUserClaims(isAuth.data.npub);
+    const userClaims = await Claim.getUserReadyClaims(user.name);
+    const npubClaims = await Claim.getUserReadyClaims(isAuth.data.npub);
     allClaims = [...userClaims, ...npubClaims];
   } else {
-    allClaims = await Claim.getUserClaims(isAuth.data.npub);
+    allClaims = await Claim.getUserReadyClaims(isAuth.data.npub);
   }
   const proofs = allClaims.map((claim) => claim.proof);
   const payload = { proofs: proofs.map((p) => ({ secret: p.secret })) };

--- a/src/controller/lnurlController.ts
+++ b/src/controller/lnurlController.ts
@@ -31,7 +31,7 @@ export async function lnurlController(
       return next(new Error("Invalid npub / public key"));
     }
   } else {
-    const userObj = await User.getUserByName(userParam);
+    const userObj = await User.getUserByName(userParam.toLowerCase());
     if (!userObj) {
       res.status(404);
       return next(new Error("User not found"));

--- a/src/controller/paidController.ts
+++ b/src/controller/paidController.ts
@@ -64,7 +64,12 @@ export async function paidController(
         newAmount,
         internalTx.mint_hash,
       );
-      Claim.createClaim(internalTx.user, process.env.MINTURL!, proofs);
+      Claim.createClaims(
+        internalTx.user,
+        process.env.MINTURL!,
+        proofs,
+        internalTx.id,
+      );
       res.sendStatus(200);
     } catch {
       return res.sendStatus(200);

--- a/src/models/claim.ts
+++ b/src/models/claim.ts
@@ -1,5 +1,10 @@
 import { Proof } from "@cashu/cashu-ts";
-import { createBulkInsertQuery, queryWrapper } from "../utils/database";
+import {
+  createBulkInsertQuery,
+  createSanitizedValueString,
+  queryWrapper,
+} from "../utils/database";
+import { ClaimStatus } from "../types";
 
 export class Claim {
   id: number;
@@ -39,6 +44,14 @@ export class Claim {
       throw new Error("Failed to create new Transaction");
     }
   }
+
+  static async updateClaimsStatus(ids: number[], status: ClaimStatus) {
+    const list = createSanitizedValueString(ids.length);
+    const query = `UPDATE l_claims_3 SET status = 'spent' WHERE id in ${list}`;
+    const res = await queryWrapper<Claim>(query, ids);
+    return res;
+  }
+
   static async getUserReadyClaims(user: string) {
     const res = await queryWrapper<Claim>(
       `SELECT * FROM l_claims_3 WHERE "user" = $1 and status = $2`,

--- a/src/models/claim.ts
+++ b/src/models/claim.ts
@@ -45,7 +45,10 @@ export class Claim {
     }
   }
 
-  static async updateClaimsStatus(ids: number[], status: ClaimStatus) {
+  static async updateClaimsStatus(ids: number[]) {
+    if (ids.length === 0) {
+      return;
+    }
     const list = createSanitizedValueString(ids.length);
     const query = `UPDATE l_claims_3 SET status = 'spent' WHERE id in ${list}`;
     const res = await queryWrapper<Claim>(query, ids);

--- a/src/models/claim.ts
+++ b/src/models/claim.ts
@@ -1,40 +1,68 @@
 import { Proof } from "@cashu/cashu-ts";
-import { queryWrapper } from "../utils/database";
+import { createBulkInsertQuery, queryWrapper } from "../utils/database";
 
 export class Claim {
   id: number;
   user: string;
   mint_url: string;
-  proofs: Proof[];
+  proof: Proof;
   status: "ready" | "inflight" | "spent";
+  transaction_id?: number;
 
   constructor(
     id: number,
     user: string,
     mint_url: string,
-    proofs: Proof[],
+    proof: Proof,
     status: "ready" | "inflight" | "spent",
+    transaction_id?: number,
   ) {
     this.id = id;
     this.user = user;
     this.mint_url = mint_url;
-    this.proofs = proofs;
+    this.proof = proof;
     this.status = status;
+    this.transaction_id = transaction_id;
   }
 
-  static async createClaim(user: string, mint_url: string, proofs: Proof[]) {
+  static async createClaim(
+    user: string,
+    mint_url: string,
+    proof: Proof,
+    transaction_id: number,
+  ) {
     const res = await queryWrapper(
-      `INSERT INTO l_claims_2 ("user", mint_url, proofs, status) VALUES ($1, $2, $3, $4)`,
-      [user, mint_url, JSON.stringify(proofs), "ready"],
+      `INSERT INTO l_claims_3 ("user", mint_url, proof, status, transaction_id) VALUES ($1, $2, $3, $4, $5)`,
+      [user, mint_url, JSON.stringify(proof), "ready", transaction_id],
     );
     if (res.rowCount === 0) {
       throw new Error("Failed to create new Transaction");
     }
   }
+  static async getUserReadyClaims(user: string) {
+    const res = await queryWrapper<Claim>(
+      `SELECT * FROM l_claims_3 WHERE "user" = $1 and status = $2`,
+      [user, "ready"],
+    );
+    if (res.rowCount === 0) {
+      return [];
+    }
+    return res.rows.map(
+      (row) =>
+        new Claim(
+          row.id,
+          row.user,
+          row.mint_url,
+          row.proof,
+          row.status,
+          row.transaction_id,
+        ),
+    );
+  }
 
   static async getUserClaims(user: string) {
     const res = await queryWrapper<Claim>(
-      `SELECT * FROM l_claims_2 WHERE "user" = $1`,
+      `SELECT * FROM l_claims_3 WHERE "user" = $1`,
       [user],
     );
     if (res.rowCount === 0) {
@@ -42,7 +70,37 @@ export class Claim {
     }
     return res.rows.map(
       (row) =>
-        new Claim(row.id, row.user, row.mint_url, row.proofs, row.status),
+        new Claim(
+          row.id,
+          row.user,
+          row.mint_url,
+          row.proof,
+          row.status,
+          row.transaction_id,
+        ),
     );
+  }
+
+  static async createClaims(
+    user: string,
+    mint_url: string,
+    proofs: Proof[],
+    transaction_id: number,
+  ) {
+    const nestedValues = proofs.map((proof) => [
+      user,
+      mint_url,
+      proof,
+      "ready",
+      transaction_id,
+    ]);
+    const res = await createBulkInsertQuery(
+      "l_claims_3",
+      [`"user"`, "mint_url", "proof", "status", "transaction_id"],
+      nestedValues,
+    );
+    if (res.rowCount === 0) {
+      throw new Error("Failed to create new Claims...");
+    }
   }
 }

--- a/src/models/transaction.ts
+++ b/src/models/transaction.ts
@@ -2,6 +2,7 @@ import { Event } from "nostr-tools";
 import { queryWrapper } from "../utils/database";
 
 export class Transaction {
+  id: number;
   mint_pr: string;
   mint_hash: string;
   server_pr: string;
@@ -11,6 +12,7 @@ export class Transaction {
   zap_request?: Event;
 
   constructor(
+    id: number,
     mintPr: string,
     mintHash: string,
     serverPr: string,
@@ -19,6 +21,7 @@ export class Transaction {
     createdAt: number,
     zapRequest?: Event,
   ) {
+    this.id = id;
     this.mint_pr = mintPr;
     this.mint_hash = mintHash;
     this.server_pr = serverPr;
@@ -46,6 +49,7 @@ VALUES ($1, $2, $3, $4, $5, $6) RETURNING id, created_at`,
       throw new Error("Failed to create new Transaction");
     }
     return new Transaction(
+      res.rows[0].id,
       mint_pr,
       mint_hash,
       server_pr,
@@ -65,6 +69,7 @@ VALUES ($1, $2, $3, $4, $5, $6) RETURNING id, created_at`,
       throw new Error("Transaction not found in db");
     }
     return new Transaction(
+      res.rows[0].id,
       res.rows[0].mint_pr,
       res.rows[0].mint_hash,
       res.rows[0].server_pr,

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -69,3 +69,5 @@ export type ZapRequestData = {
   relays: string[];
   amount?: number;
 };
+
+export type ClaimStatus = "ready" | "inflight" | "spent";

--- a/src/utils/database.test.ts
+++ b/src/utils/database.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "@jest/globals";
+import { createBulkInsertPayload } from "./database";
+
+describe("Bulk Insert", () => {
+  test("create buld insert string", () => {
+    const columns = ["name", "age", "gender"];
+    const values = [
+      ["Dan", 24, "male"],
+      ["Anna", 21, "female"],
+      ["Steve", 36, "male"],
+      ["Steve", 36, "male"],
+    ];
+    const invalidValues = [["Dan", "hockey", 23, "male"]];
+    const insertString = createBulkInsertPayload(columns, values);
+    expect(insertString.flatValues.length).toBe(12);
+    expect(() => createBulkInsertPayload(columns, invalidValues)).toThrow();
+  });
+});

--- a/src/utils/database.ts
+++ b/src/utils/database.ts
@@ -43,3 +43,7 @@ export function createBulkInsertQuery<T extends QueryResultRow>(
   };`;
   return pool.query<T>(query, payload.flatValues);
 }
+
+export function createSanitizedValueString(n) {
+  return `(${Array.from({ length: n }, (_, i) => `$${i + 1}`).join(", ")})`;
+}

--- a/src/utils/database.ts
+++ b/src/utils/database.ts
@@ -8,3 +8,38 @@ export function queryWrapper<T extends QueryResultRow>(
 ) {
   return pool.query<T>(query, values);
 }
+
+export function createBulkInsertPayload(
+  columnArray: string[],
+  nestedValueArray: any[][],
+) {
+  let counter = 1;
+  const sanitizedValueArray: string[] = [];
+  nestedValueArray.forEach((innerArray) => {
+    if (columnArray.length !== innerArray.length) {
+      throw new Error("Value-Column mismatch");
+    }
+    const innerSanitizedValueArray: string[] = [];
+    for (let i = 0; i < innerArray.length; i++) {
+      innerSanitizedValueArray.push(`$${counter}`);
+      counter++;
+    }
+    sanitizedValueArray.push(innerSanitizedValueArray.join(","));
+  });
+  const valueStrings = sanitizedValueArray
+    .map((innerValue) => `(${innerValue})`)
+    .join(",");
+  return { valueString: valueStrings, flatValues: nestedValueArray.flat() };
+}
+
+export function createBulkInsertQuery<T extends QueryResultRow>(
+  tableName: string,
+  columnArray: string[],
+  nestedValueArray: any[][],
+) {
+  const payload = createBulkInsertPayload(columnArray, nestedValueArray);
+  const query = `INSERT INTO ${tableName} (${columnArray.join(",")}) VALUES ${
+    payload.valueString
+  };`;
+  return pool.query<T>(query, payload.flatValues);
+}


### PR DESCRIPTION
This PR introduces two fundamental changes to the Claim schema:

1. Claims are now mapped to a Transaction (Relational key constraint).
2. Claims now only hold a single Proof. If a Transaction includes multiple proofs, multiple claims will be created

The reason for this change is, that it makes it a lot easier to keep the database clean. This PR also includes logic to regularly (when user check their balance) check if tokens currently marked as "ready" are still unspent and updates their status if they are not. Claim route and balance route also no longer select ALL proofs but only those with status as "ready"