### PR TITLE
Add support for user-selected mints

### DIFF
--- a/src/controller/claimController.ts
+++ b/src/controller/claimController.ts
@@ -16,7 +16,7 @@ export async function balanceController(req: Request, res: Response) {
   const payload = {
     proofs: proofs.map((p) => ({ secret: p.secret })),
   };
-  const { spendable } = await new CashuMint(process.env.MINTURL!).check(
+  const { spendable } = await new CashuMint(allClaims[0].mint_url).check(
     payload,
   );
   const spendableProofs: Proof[] = [];
@@ -50,7 +50,7 @@ export async function claimGetController(req: Request, res: Response) {
   const spendableProofs = proofs.filter((_, i) => spendable[i]);
   const token = getEncodedToken({
     memo: "",
-    token: [{ mint: process.env.MINTURL!, proofs: spendableProofs }],
+    token: [{ mint: allClaims[0].mint_url, proofs: spendableProofs }],
   });
   if (spendableProofs.length === 0) {
     return res.json({ error: true, message: "No proofs to claim" });

--- a/src/controller/paidController.ts
+++ b/src/controller/paidController.ts
@@ -67,7 +67,7 @@ export async function paidController(
       );
       await Claim.createClaims(
         internalTx.user,
-        process.env.MINTURL!,
+        internalTx.mint_url,
         proofs,
         internalTx.id,
       );

--- a/src/controller/paidController.ts
+++ b/src/controller/paidController.ts
@@ -1,7 +1,8 @@
 import { Request, Response } from "express";
-import { lnProvider, nostrPool, wallet } from "..";
+import { lnProvider, nostrPool } from "..";
 import { Claim, Transaction } from "../models";
 import { createZapReceipt, extractZapRequestData } from "../utils/nostr";
+import { getWalletFromCache } from "../utils/mint";
 
 const relays = [
   "wss://relay.current.fyi",
@@ -59,6 +60,7 @@ export async function paidController(
         console.error(e);
         console.error("Could not pay mint invoice!");
       }
+      const wallet = getWalletFromCache(internalTx.mint_url);
       const { proofs } = await wallet.requestTokens(
         transaction.settlementAmount,
         internalTx.mint_hash,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,6 @@
 import express, { Response } from "express";
 import bodyparser from "body-parser";
 import cors from "cors";
-import { CashuMint, CashuWallet } from "@cashu/cashu-ts";
 
 import routes from "./routes";
 import { LightningHandler } from "./utils/lightning";
@@ -20,7 +19,6 @@ useWebSocketImplementation(require("ws"));
 
 checkEnvVars(["LNURL_MAX_AMOUNT", "LNURL_MIN_AMOUNT", "MINTURL"]);
 
-export const wallet = new CashuWallet(new CashuMint(process.env.MINTURL!));
 export const lnProvider = new LightningHandler(new BlinkProvider());
 export const nostrPool = new SimplePool();
 

--- a/src/models/transaction.ts
+++ b/src/models/transaction.ts
@@ -13,6 +13,7 @@ export class Transaction {
   zap_request: Event | undefined;
   fulfilled: boolean;
   amount: number;
+  mint_url: string;
 
   constructor(
     id: number,
@@ -25,6 +26,7 @@ export class Transaction {
     zapRequest: Event | undefined,
     fulfilled: boolean,
     amount: number,
+    mint_url: string,
   ) {
     this.id = id;
     this.mint_pr = mintPr;
@@ -36,6 +38,7 @@ export class Transaction {
     this.zap_request = zapRequest;
     this.fulfilled = fulfilled;
     this.amount = amount;
+    this.mint_url = mint_url;
   }
 
   async recordFailedPayment() {
@@ -74,11 +77,12 @@ export class Transaction {
     user: string,
     zapRequest: Event | undefined,
     amount: number,
+    mint_url: string,
   ) {
     const res = await queryWrapper<Transaction>(
       `INSERT INTO l_transactions
-(mint_pr, mint_hash, server_pr, server_hash, "user", zap_request, fulfilled, amount)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING id, created_at`,
+(mint_pr, mint_hash, server_pr, server_hash, "user", zap_request, fulfilled, amount, mint_url)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) RETURNING id, created_at`,
       [
         mint_pr,
         mint_hash,
@@ -88,6 +92,7 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING id, created_at`,
         zapRequest,
         false,
         amount,
+        mint_url,
       ],
     );
     if (res.rowCount === 0) {
@@ -104,6 +109,7 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING id, created_at`,
       zapRequest,
       false,
       amount,
+      mint_url,
     );
   }
 
@@ -126,6 +132,7 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING id, created_at`,
       res.rows[0].zap_request,
       res.rows[0].fulfilled,
       res.rows[0].amount,
+      res.rows[0].mint_url,
     );
   }
 }

--- a/src/utils/__tests__/mint.test.ts
+++ b/src/utils/__tests__/mint.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "vitest";
+import { isValidMint } from "../mint";
+
+describe("Verify Mint Url", () => {
+  test("Valid Mint URL", async () => {
+    const isValid = await isValidMint("https://mint.minibits.cash/Bitcoin");
+    expect(isValid).toBe(true);
+  });
+  test("Invalid URL", async () => {
+    const isValid = await isValidMint("Not a url");
+    expect(isValid).toBe(false);
+  });
+  test("Valid URL, but not a mint", async () => {
+    const isValid = await isValidMint("https://bitcoin.org");
+    expect(isValid).toBe(false);
+  });
+});

--- a/src/utils/__tests__/mint.test.ts
+++ b/src/utils/__tests__/mint.test.ts
@@ -1,5 +1,11 @@
-import { describe, expect, test } from "vitest";
-import { isValidMint } from "../mint";
+import { afterEach, describe, expect, test } from "vitest";
+import {
+  cashuWalletMap,
+  clearWalletCache,
+  getWalletFromCache,
+  isValidMint,
+} from "../mint";
+import { CashuMint, CashuWallet } from "@cashu/cashu-ts";
 
 describe("Verify Mint Url", () => {
   test("Valid Mint URL", async () => {
@@ -13,5 +19,34 @@ describe("Verify Mint Url", () => {
   test("Valid URL, but not a mint", async () => {
     const isValid = await isValidMint("https://bitcoin.org");
     expect(isValid).toBe(false);
+  });
+});
+
+describe("Mint cache", () => {
+  afterEach(() => {
+    clearWalletCache();
+  });
+  test("Get a stored mint from cache", () => {
+    const url = "https://mint.minibits.cash/Bitcoin";
+    const newMint = new CashuWallet(new CashuMint(url));
+    cashuWalletMap[url] = newMint;
+    const cachedWallet = getWalletFromCache(url);
+    expect(cachedWallet).toBe(newMint);
+  });
+  test("clearing wallet cache", () => {
+    const url = "https://mint.minibits.cash/Bitcoin";
+    const newMint = new CashuWallet(new CashuMint(url));
+    cashuWalletMap[url] = newMint;
+    expect(Object.keys(cashuWalletMap).length).toBe(1);
+    clearWalletCache();
+    expect(Object.keys(cashuWalletMap).length).toBe(0);
+  });
+  test("Adding 2 mints to cache", () => {
+    getWalletFromCache("https://mint.minibits.cash/Bitcoin");
+    expect(Object.keys(cashuWalletMap).length).toBe(1);
+    getWalletFromCache("https://mint.macadamia.cash");
+    expect(Object.keys(cashuWalletMap).length).toBe(2);
+    getWalletFromCache("https://mint.macadamia.cash");
+    expect(Object.keys(cashuWalletMap).length).toBe(2);
   });
 });

--- a/src/utils/mint.ts
+++ b/src/utils/mint.ts
@@ -1,3 +1,23 @@
+import { CashuMint, CashuWallet } from "@cashu/cashu-ts";
+
+export const cashuWalletMap: { [mintUrl: string]: CashuWallet } = {};
+
+export function getWalletFromCache(mintUrl: string) {
+  if (cashuWalletMap[mintUrl]) {
+    return cashuWalletMap[mintUrl];
+  }
+  const newWallet = new CashuWallet(new CashuMint(mintUrl));
+  cashuWalletMap[mintUrl] = newWallet;
+  return newWallet;
+}
+
+export function clearWalletCache() {
+  const keys = Object.keys(cashuWalletMap);
+  keys.forEach((k) => {
+    delete cashuWalletMap[k];
+  });
+}
+
 export async function isValidMint(url: string) {
   try {
     new URL(url);

--- a/src/utils/mint.ts
+++ b/src/utils/mint.ts
@@ -1,0 +1,13 @@
+export async function isValidMint(url: string) {
+  try {
+    new URL(url);
+    const res = await fetch(`${url}/v1/info`);
+    const data = await res.json();
+    if (!data.pubkey) {
+      return false;
+    }
+    return true;
+  } catch (e) {
+    return false;
+  }
+}


### PR DESCRIPTION
As of right now npubcash-server only works with a single mint that is defined by the service provider. This PR lets users choose their own mint and makes sure the server uses that mint to request ecash from.