### PR TITLE
v3-feat(server): skip username payment when cost is 0

### DIFF
--- a/packages/server/src/config/env.test.ts
+++ b/packages/server/src/config/env.test.ts
@@ -125,6 +125,31 @@ describe("env.ts", () => {
       mintUrl: "https://mint.example.com",
       amount: 1000,
     });
+
+    process.env.USERNAME_COST = "0";
+    expect(getUsernameConfigFromEnv()).toEqual({
+      enabled: true,
+      mintUrl: "https://mint.example.com",
+      amount: 0,
+    });
+  });
+
+  test("getUsernameConfigFromEnv rejects invalid costs", () => {
+    process.env.USERNAME_MINT = "https://mint.example.com";
+
+    for (const usernameCost of [
+      "invalid",
+      "-1",
+      "1.5",
+      "1e3",
+      " ",
+      "9007199254740992",
+    ]) {
+      process.env.USERNAME_COST = usernameCost;
+      expect(() => getUsernameConfigFromEnv()).toThrow(
+        "USERNAME_COST must be a non-negative integer",
+      );
+    }
   });
 
   test("getRelaysFromEnv parses comma-separated relays", () => {

--- a/packages/server/src/config/env.ts
+++ b/packages/server/src/config/env.ts
@@ -105,10 +105,14 @@ export function getUsernameConfigFromEnv():
   if (!usernameMint || !usernameCost) {
     return { enabled: false };
   }
+  const amount = Number(usernameCost);
+  if (!/^\d+$/.test(usernameCost) || !Number.isSafeInteger(amount)) {
+    throw new Error("USERNAME_COST must be a non-negative integer");
+  }
   return {
     enabled: true,
     mintUrl: usernameMint,
-    amount: parseInt(usernameCost),
+    amount,
   };
 }
 

--- a/packages/server/src/controller/username.test.ts
+++ b/packages/server/src/controller/username.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { PaymentRequiredError } from "@/errors";
+import type { NextFunction, Request, Response } from "express";
+
+const mintUrl = "https://mint.example.com";
+const createdUser = { pubkey: "pubkey", username: "alice" };
+const decodedToken = { mint: mintUrl, proofs: [{ amount: 1000 }] };
+const redeemedProofs = [{ amount: 1000 }];
+
+const usernameConfig = {
+  enabled: true,
+  mintUrl,
+  amount: 0,
+};
+
+const validateAndParseUsername = mock((username: string) => username);
+const usernameExists = mock(async (_username: string) => false);
+const setUsername = mock(async (_pubkey: string, _username: string) =>
+  createdUser,
+);
+const getDecodedToken = mock((_token: string) => decodedToken);
+const redeemToken = mock(async (_token: typeof decodedToken) => redeemedProofs);
+const saveProofs = mock(async (_proofs: typeof redeemedProofs) => {});
+
+mock.module("@/config", () => ({
+  communicatorService: { redeemToken },
+  proofService: { saveProofs },
+  userService: {
+    setUsername,
+    usernameExists,
+    validateAndParseUsername,
+  },
+}));
+
+mock.module("../config/index", () => ({
+  config: { usernameConfig },
+}));
+
+mock.module("@cashu/cashu-ts", () => ({ getDecodedToken }));
+
+const { usernameController } = await import("./username");
+
+afterEach(() => {
+  usernameConfig.amount = 0;
+  mock.clearAllMocks();
+});
+
+describe("usernameController", () => {
+  test("creates a free username without checking for payment", async () => {
+    const { req, header } = createRequest();
+    const { res, status, json } = createResponse();
+    const next = mock((_error?: unknown) => {});
+
+    await usernameController(req, res, next as NextFunction);
+
+    expect(header).not.toHaveBeenCalled();
+    expect(getDecodedToken).not.toHaveBeenCalled();
+    expect(redeemToken).not.toHaveBeenCalled();
+    expect(saveProofs).not.toHaveBeenCalled();
+    expect(setUsername).toHaveBeenCalledWith("pubkey", "alice");
+    expect(status).toHaveBeenCalledWith(201);
+    expect(json).toHaveBeenCalledWith({
+      error: false,
+      data: { user: createdUser },
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test("requires payment for a positive username cost", async () => {
+    usernameConfig.amount = 1000;
+    const { req, header } = createRequest();
+    const { res } = createResponse();
+    const next = mock((_error?: unknown) => {});
+
+    await usernameController(req, res, next as NextFunction);
+
+    expect(header).toHaveBeenCalledWith("X-Cashu");
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next.mock.calls[0]?.[0]).toBeInstanceOf(PaymentRequiredError);
+    expect(next.mock.calls[0]?.[0]).toMatchObject({ amount: 1000, mintUrl });
+    expect(setUsername).not.toHaveBeenCalled();
+  });
+
+  test("redeems and saves a valid payment before creating a username", async () => {
+    usernameConfig.amount = 1000;
+    const { req } = createRequest("token");
+    const { res, status } = createResponse();
+    const next = mock((_error?: unknown) => {});
+
+    await usernameController(req, res, next as NextFunction);
+
+    expect(getDecodedToken).toHaveBeenCalledWith("token");
+    expect(redeemToken).toHaveBeenCalledWith(decodedToken);
+    expect(saveProofs).toHaveBeenCalledWith(redeemedProofs);
+    expect(setUsername).toHaveBeenCalledWith("pubkey", "alice");
+    expect(status).toHaveBeenCalledWith(201);
+    expect(next).not.toHaveBeenCalled();
+  });
+});
+
+function createRequest(xCashu?: string) {
+  const header = mock((_name: string) => xCashu);
+  const req = {
+    authData: { data: { pubkey: "pubkey" } },
+    body: { username: "alice" },
+    header,
+  } as unknown as Request<unknown, unknown, { username: string }>;
+
+  return { req, header };
+}
+
+function createResponse() {
+  const res = {} as Response;
+  const status = mock((_status: number) => res);
+  const json = mock((_body: unknown) => res);
+  Object.assign(res, { json, status });
+
+  return { res, status, json };
+}

--- a/packages/server/src/controller/username.ts
+++ b/packages/server/src/controller/username.ts
@@ -33,13 +33,15 @@ export async function usernameController(
       throw new UsernameTakenError();
     }
 
-    const xCashu = req.header("X-Cashu");
-    if (!xCashu) {
-      throw new PaymentRequiredError(amount, mintUrl);
+    if (amount > 0) {
+      const xCashu = req.header("X-Cashu");
+      if (!xCashu) {
+        throw new PaymentRequiredError(amount, mintUrl);
+      }
+      const decodedToken = await validatePayment(xCashu, amount, mintUrl);
+      const newProofs = await communicatorService.redeemToken(decodedToken);
+      await proofService.saveProofs(newProofs);
     }
-    const decodedToken = await validatePayment(xCashu, amount, mintUrl);
-    const newProofs = await communicatorService.redeemToken(decodedToken);
-    await proofService.saveProofs(newProofs);
     const user = await userService.setUsername(
       authData.data.pubkey,
       parsedUsername,

--- a/packages/server/src/controller/username.ts
+++ b/packages/server/src/controller/username.ts
@@ -33,7 +33,7 @@ export async function usernameController(
       throw new UsernameTakenError();
     }
 
-    if (amount > 0) {
+    if (amount !== 0) {
       const xCashu = req.header("X-Cashu");
       if (!xCashu) {
         throw new PaymentRequiredError(amount, mintUrl);


### PR DESCRIPTION
when `USERNAME_COST=0' in env, skip the X-Cashu payment check in the username controller.