### PR TITLE
Upgrade cashu-ts to v1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "npubcash-website"
       ],
       "dependencies": {
-        "@cashu/cashu-ts": "^0.8.2-rc.7",
+        "@cashu/cashu-ts": "1.0.0",
         "compression": "^1.7.4",
         "cors": "^2.8.5",
         "express": "^4.18.2",
@@ -784,14 +784,15 @@
       "dev": true
     },
     "node_modules/@cashu/cashu-ts": {
-      "version": "0.8.2-rc.7",
-      "resolved": "https://registry.npmjs.org/@cashu/cashu-ts/-/cashu-ts-0.8.2-rc.7.tgz",
-      "integrity": "sha512-Csvs8BQGdCAqMuoDPYVMAH1h1Z+3qXZfc8V2bxIaMaFWq4O9y/kMIx6uvB1D82+hrjHywpVihMPp9TYCCs3Vjw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@cashu/cashu-ts/-/cashu-ts-1.0.0.tgz",
+      "integrity": "sha512-WiA803cDMlccqe/9NN7AhEQxb1X4feQ80I6rOOBM44SVfisW6npule3+VKfwqqFtJBF325iQUyHzf7RAC/iYsw==",
+      "deprecated": "Deprecated: this version is no longer supported and may be incompatible with the current Cashu spec. Please upgrade to v4, or use @cashu/cashu-ts@v3-lts if you require the current security-fixes-only LTS.",
       "dependencies": {
-        "@gandlaf21/bolt11-decode": "^3.0.6",
-        "@noble/curves": "^1.0.0",
-        "@scure/bip32": "^1.3.2",
-        "@scure/bip39": "^1.2.1",
+        "@noble/curves": "^1.3.0",
+        "@noble/hashes": "^1.3.3",
+        "@scure/bip32": "^1.3.3",
+        "@scure/bip39": "^1.2.2",
         "buffer": "^6.0.3"
       }
     },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@cashu/cashu-ts": "^0.8.2-rc.7",
+    "@cashu/cashu-ts": "1.0.0",
     "compression": "^1.7.4",
     "cors": "^2.8.5",
     "express": "^4.18.2",

--- a/src/controller/__tests__/claimController.test.ts
+++ b/src/controller/__tests__/claimController.test.ts
@@ -1,0 +1,185 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { claimGetController } from "../claimController";
+
+const mocks = vi.hoisted(() => ({
+  check: vi.fn(),
+  getEncodedToken: vi.fn(),
+  getPaginatedUserReadyClaims: vi.fn(),
+  getUserByPubkey: vi.fn(),
+  saveWithdrawal: vi.fn(),
+  state: "UNSPENT",
+  states: undefined as string[] | undefined,
+}));
+
+vi.mock("@cashu/cashu-ts", () => ({
+  CashuMint: class {
+    check = mocks.check;
+  },
+  CheckStateEnum: {
+    UNSPENT: "UNSPENT",
+    PENDING: "PENDING",
+    SPENT: "SPENT",
+  },
+  getEncodedToken: mocks.getEncodedToken,
+}));
+
+vi.mock("../../models", () => ({
+  Claim: {
+    getPaginatedUserReadyClaims: mocks.getPaginatedUserReadyClaims,
+  },
+  User: { getUserByPubkey: mocks.getUserByPubkey },
+}));
+
+vi.mock("../../models/withdrawal", () => ({
+  WithdrawalStore: {
+    getInstance: () => ({ saveWithdrawal: mocks.saveWithdrawal }),
+  },
+}));
+
+describe("claimGetController", () => {
+  const proof = {
+    amount: 8,
+    id: "keyset-id",
+    secret: "proof-secret",
+    C: "proof-signature",
+  };
+  const claim = { id: 7, proof };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv("MINTURL", "https://mint.example");
+    mocks.state = "UNSPENT";
+    mocks.states = undefined;
+    mocks.getUserByPubkey.mockResolvedValue(undefined);
+    mocks.getPaginatedUserReadyClaims.mockResolvedValue({
+      claims: [claim],
+      count: 1,
+      totalPending: 1,
+    });
+    mocks.check.mockImplementation(async ({ Ys }: { Ys: string[] }) => ({
+      states: Ys.map((Y, index) => ({
+        Y,
+        state: mocks.states?.[index] ?? mocks.state,
+        witness: null,
+      })),
+    }));
+    mocks.getEncodedToken.mockReturnValue("encoded-token");
+  });
+
+  it("returns and records an unspent proof", async () => {
+    const json = vi.fn();
+
+    await claimGetController(
+      {
+        authData: {
+          authorized: true,
+          data: { pubkey: "pubkey", npub: "npub1recipient" },
+        },
+      } as never,
+      { json, status: vi.fn() } as never,
+    );
+
+    expect(mocks.getEncodedToken).toHaveBeenCalledWith({
+      memo: "",
+      token: [{ mint: "https://mint.example", proofs: [proof] }],
+    });
+    expect(mocks.saveWithdrawal).toHaveBeenCalledWith([claim], "pubkey");
+    expect(json).toHaveBeenCalledWith({
+      error: false,
+      data: { token: "encoded-token", count: 1, totalPending: 1 },
+    });
+  });
+
+  it("does not return or record a pending proof", async () => {
+    mocks.state = "PENDING";
+    const json = vi.fn();
+
+    await claimGetController(
+      {
+        authData: {
+          authorized: true,
+          data: { pubkey: "pubkey", npub: "npub1recipient" },
+        },
+      } as never,
+      { json, status: vi.fn() } as never,
+    );
+
+    expect(mocks.getEncodedToken).not.toHaveBeenCalled();
+    expect(mocks.saveWithdrawal).not.toHaveBeenCalled();
+    expect(json).toHaveBeenCalledWith({
+      error: true,
+      message: "No proofs to claim",
+    });
+  });
+
+  it("excludes a spent proof from the token, withdrawal, and count", async () => {
+    const spentClaim = {
+      id: 8,
+      proof: {
+        amount: 4,
+        id: "keyset-id",
+        secret: "spent-secret",
+        C: "spent-signature",
+      },
+    };
+    mocks.getPaginatedUserReadyClaims.mockResolvedValue({
+      claims: [claim, spentClaim],
+      count: 2,
+      totalPending: 2,
+    });
+    mocks.states = ["UNSPENT", "UNSPENT", "SPENT", "SPENT"];
+    const json = vi.fn();
+
+    await claimGetController(
+      {
+        authData: {
+          authorized: true,
+          data: { pubkey: "pubkey", npub: "npub1recipient" },
+        },
+      } as never,
+      { json, status: vi.fn() } as never,
+    );
+
+    expect(mocks.getEncodedToken).toHaveBeenCalledWith({
+      memo: "",
+      token: [{ mint: "https://mint.example", proofs: [proof] }],
+    });
+    expect(mocks.saveWithdrawal).toHaveBeenCalledWith([claim], "pubkey");
+    expect(json).toHaveBeenCalledWith({
+      error: false,
+      data: { token: "encoded-token", count: 1, totalPending: 2 },
+    });
+  });
+
+  it("does not return a proof spent under its legacy identifier", async () => {
+    mocks.check.mockImplementationOnce(async ({ Ys }: { Ys: string[] }) => ({
+      states:
+        Ys.length === 2
+          ? [
+              { Y: Ys[0], state: "UNSPENT", witness: null },
+              { Y: Ys[1], state: "SPENT", witness: null },
+            ]
+          : [{ Y: Ys[0], state: "UNSPENT", witness: null }],
+    }));
+    const json = vi.fn();
+
+    await claimGetController(
+      {
+        authData: {
+          authorized: true,
+          data: { pubkey: "pubkey", npub: "npub1recipient" },
+        },
+      } as never,
+      { json, status: vi.fn() } as never,
+    );
+
+    expect(mocks.check).toHaveBeenCalledTimes(1);
+    expect(mocks.check.mock.calls[0][0].Ys).toHaveLength(2);
+    expect(mocks.getEncodedToken).not.toHaveBeenCalled();
+    expect(mocks.saveWithdrawal).not.toHaveBeenCalled();
+    expect(json).toHaveBeenCalledWith({
+      error: true,
+      message: "No proofs to claim",
+    });
+  });
+});

--- a/src/controller/__tests__/lnurlController.test.ts
+++ b/src/controller/__tests__/lnurlController.test.ts
@@ -41,7 +41,7 @@ vi.mock("nostr-tools", () => ({
 
 vi.mock("../../config.ts", () => ({
   wallet: {
-    requestMint: vi.fn(),
+    getMintQuote: vi.fn(),
   },
   lnProvider: {
     createInvoice: vi.fn(),
@@ -124,9 +124,10 @@ describe("lnurlController", () => {
       mint_url: "https://mint.minibits.cash/Bitcoin",
       pubkey: "testPubkey...",
     });
-    vi.mocked(wallet.requestMint).mockResolvedValue({
-      pr: "lnbc15u1p3xnhl2pp5jptserfk3zk4qy42tlucycrfwxhydvlemu9pqr93tuzlv9cc7g3sdqsvfhkcap3xyhx7un8cqzpgxqzjcsp5f8c52y2stc300gl6s4xswtjpc37hrnnr3c9wvtgjfuvqmpm35evq9qyyssqy4lgd8tj637qcjp05rdpxxykjenthxftej7a2zzmwrmrl70fyj9hvj0rewhzj7jfyuwkwcg9g2jpwtk3wkjtwnkdks84hsnu8xps5vsq4gj5hs",
-      hash: "456",
+    vi.mocked(wallet.getMintQuote).mockResolvedValue({
+      request:
+        "lnbc15u1p3xnhl2pp5jptserfk3zk4qy42tlucycrfwxhydvlemu9pqr93tuzlv9cc7g3sdqsvfhkcap3xyhx7un8cqzpgxqzjcsp5f8c52y2stc300gl6s4xswtjpc37hrnnr3c9wvtgjfuvqmpm35evq9qyyssqy4lgd8tj637qcjp05rdpxxykjenthxftej7a2zzmwrmrl70fyj9hvj0rewhzj7jfyuwkwcg9g2jpwtk3wkjtwnkdks84hsnu8xps5vsq4gj5hs",
+      quote: "456",
     });
     const lnProviderMock = vi
       .mocked(lnProvider.createInvoice, { partial: true })
@@ -158,6 +159,15 @@ describe("lnurlController", () => {
       1500,
       "Cashu Address",
       undefined,
+    );
+    expect(Transaction.createTransaction).toHaveBeenCalledWith(
+      expect.stringMatching(/^lnbc/),
+      "456",
+      "invoice",
+      "hash",
+      "testUser",
+      undefined,
+      21,
     );
 
     expect(res.status).toBe(200);

--- a/src/controller/__tests__/paidController.test.ts
+++ b/src/controller/__tests__/paidController.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { paidController } from "../paidController";
+
+const mocks = vi.hoisted(() => ({
+  createClaims: vi.fn(),
+  getTransactionByHash: vi.fn(),
+  logPaymentSettled: vi.fn(),
+  mintTokens: vi.fn(),
+  payInvoice: vi.fn(),
+  setToFulfilled: vi.fn(),
+}));
+
+vi.mock("../../config", () => ({
+  lnProvider: { payInvoice: mocks.payInvoice },
+  wallet: { mintTokens: mocks.mintTokens },
+}));
+
+vi.mock("../../models", () => ({
+  Claim: { createClaims: mocks.createClaims },
+  Transaction: {
+    getTransactionByHash: mocks.getTransactionByHash,
+    setToFulfilled: mocks.setToFulfilled,
+  },
+}));
+
+vi.mock("../../utils/analytics", () => ({
+  Analyzer: {
+    getInstance: () => ({ logPaymentSettled: mocks.logPaymentSettled }),
+  },
+}));
+
+vi.mock("../../utils/nostr", () => ({
+  createZapReceipt: vi.fn(),
+  extractZapRequestData: vi.fn(),
+  publishZapReceipt: vi.fn(),
+}));
+
+describe("paidController", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv("MINTURL", "https://mint.example");
+  });
+
+  it("mints the settled amount with the stored quote and persists its proofs", async () => {
+    const transaction = {
+      id: 42,
+      mint_pr: "mint-invoice",
+      mint_hash: "mint-quote",
+      user: "npub1recipient",
+      zap_request: undefined,
+      recordFailedPayment: vi.fn(),
+    };
+    const proofs = [
+      { amount: 21, id: "keyset-id", secret: "secret", C: "signature" },
+    ];
+    mocks.getTransactionByHash.mockResolvedValue(transaction);
+    mocks.mintTokens.mockResolvedValue({ proofs });
+    const sendStatus = vi.fn();
+
+    await paidController(
+      {
+        body: {
+          eventType: "receive.lightning",
+          transaction: {
+            memo: "payment",
+            settlementAmount: 21,
+            initiationVia: { paymentHash: "server-payment-hash" },
+          },
+        },
+      } as never,
+      { sendStatus } as never,
+    );
+
+    expect(mocks.mintTokens).toHaveBeenCalledWith(21, "mint-quote");
+    expect(mocks.createClaims).toHaveBeenCalledWith(
+      "npub1recipient",
+      "https://mint.example",
+      proofs,
+      42,
+    );
+    expect(mocks.setToFulfilled).toHaveBeenCalledWith(42);
+    expect(sendStatus).toHaveBeenCalledWith(200);
+  });
+});

--- a/src/controller/claimController.ts
+++ b/src/controller/claimController.ts
@@ -1,7 +1,12 @@
 import { Request, Response } from "express";
-import { CashuMint, getEncodedToken } from "@cashu/cashu-ts";
+import {
+  CashuMint,
+  CheckStateEnum,
+  getEncodedToken,
+} from "@cashu/cashu-ts";
 import { Claim, User } from "../models";
 import { WithdrawalStore } from "../models/withdrawal";
+import { getProofStateYs } from "../utils/cashu";
 
 export async function balanceController(req: Request, res: Response) {
   const isAuth = req.authData!;
@@ -28,29 +33,40 @@ export async function claimGetController(req: Request, res: Response) {
   if (allClaims.count === 0) {
     return res.json({ error: true, message: "No proofs to claim" });
   }
-  const proofs = allClaims.claims.map((claim) => claim.proof);
-  const payload = { proofs: proofs.map((p) => ({ secret: p.secret })) };
-  const { spendable } = await new CashuMint(process.env.MINTURL!).check(
-    payload,
+  const proofYs = allClaims.claims.map((claim) =>
+    getProofStateYs(claim.proof.secret),
   );
-  const spendableProofs = proofs.filter((_, i) => spendable[i]);
+  const { states } = await new CashuMint(process.env.MINTURL!).check({
+    Ys: proofYs.flatMap(({ current, legacy }) => [current, legacy]),
+  });
+  const spendableClaims = allClaims.claims.filter((_, index) => {
+    const { current, legacy } = proofYs[index];
+    return [current, legacy].every((proofY) => {
+      const proofStates = states.filter(({ Y }) => Y === proofY);
+      return (
+        proofStates.length > 0 &&
+        proofStates.every(({ state }) => state === CheckStateEnum.UNSPENT)
+      );
+    });
+  });
+  const spendableProofs = spendableClaims.map((claim) => claim.proof);
+  if (spendableProofs.length === 0) {
+    return res.json({ error: true, message: "No proofs to claim" });
+  }
   try {
     await WithdrawalStore.getInstance()?.saveWithdrawal(
-      allClaims.claims,
+      spendableClaims,
       req.authData!.data.pubkey,
     );
     const token = getEncodedToken({
       memo: "",
       token: [{ mint: process.env.MINTURL!, proofs: spendableProofs }],
     });
-    if (spendableProofs.length === 0) {
-      return res.json({ error: true, message: "No proofs to claim" });
-    }
     res.json({
       error: false,
       data: {
         token: token,
-        count: allClaims.claims.length,
+        count: spendableClaims.length,
         totalPending: allClaims.count,
       },
     });

--- a/src/controller/lnurlController.ts
+++ b/src/controller/lnurlController.ts
@@ -64,8 +64,8 @@ export async function lnurlController(
     mintHash: string,
     invoiceRes: { paymentRequest: string; paymentHash: string };
   try {
-    const mintRes = await wallet.requestMint(Math.floor(parsedAmount / 1000));
-    ({ pr: mintPr, hash: mintHash } = mintRes);
+    const mintRes = await wallet.getMintQuote(Math.floor(parsedAmount / 1000));
+    ({ request: mintPr, quote: mintHash } = mintRes);
   } catch (e) {
     console.log("Failed to create invoice: Mint failed");
     console.log(e);

--- a/src/controller/paidController.ts
+++ b/src/controller/paidController.ts
@@ -66,7 +66,7 @@ export async function paidController(
         console.error(e);
         console.error("Could not pay mint invoice!");
       }
-      const { proofs } = await wallet.requestTokens(
+      const { proofs } = await wallet.mintTokens(
         transaction.settlementAmount,
         internalTx.mint_hash,
       );

--- a/src/utils/__tests__/cashu.test.ts
+++ b/src/utils/__tests__/cashu.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { hashToCurve } from "@cashu/cashu-ts/dist/lib/es5/DHKE";
+import { legacyHashToCurve } from "../cashu";
+
+describe("cashu hash to curve", () => {
+  it("uses the domain-separated Cashu hash-to-curve vector", () => {
+    const secret = new Uint8Array(32);
+
+    expect(hashToCurve(secret).toHex(true)).toBe(
+      "024cce997d3b518f739663b757deaec95bcd9473c30a14ac2fd04023a739d1a725",
+    );
+  });
+
+  it("retains the legacy identifier for stored-proof state checks", () => {
+    const secret = new Uint8Array(32);
+
+    expect(legacyHashToCurve(secret)).toBe(
+      "0266687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925",
+    );
+  });
+});

--- a/src/utils/cashu.ts
+++ b/src/utils/cashu.ts
@@ -1,0 +1,31 @@
+import { createHash } from "crypto";
+import {
+  hashToCurve,
+  pointFromHex,
+} from "@cashu/cashu-ts/dist/lib/es5/DHKE";
+
+export type ProofStateYs = {
+  current: string;
+  legacy: string;
+};
+
+export function getProofStateYs(secret: string): ProofStateYs {
+  const message = new TextEncoder().encode(secret);
+  return {
+    current: hashToCurve(message).toHex(true),
+    legacy: legacyHashToCurve(message),
+  };
+}
+
+export function legacyHashToCurve(message: Uint8Array): string {
+  let messageToHash = message;
+  for (let counter = 0; counter < 2 ** 16; counter++) {
+    const hash = createHash("sha256").update(messageToHash).digest();
+    try {
+      return pointFromHex(`02${hash.toString("hex")}`).toHex(true);
+    } catch {
+      messageToHash = hash;
+    }
+  }
+  throw new Error("No valid legacy hash-to-curve point found");
+}


### PR DESCRIPTION
## Summary

- pin the backend to `@cashu/cashu-ts` `1.0.0`
- migrate mint quote creation from `requestMint` to `getMintQuote`
- migrate settled-payment minting from `requestTokens` to `mintTokens`
- update claim-state checks to the v1 `{ Ys }` / `{ states }` API
- distinguish `UNSPENT`, `PENDING`, and `SPENT`, recording only proofs returned to the user
- add focused coverage for the quote-to-mint flow, claim states, and v1 proof identifiers

## Why

The backend was still using the `0.8.2-rc.7` prerelease and its pre-v1 mint interfaces. Upgrading keeps proof creation and claim-state handling compatible with the mint's v1 API while retaining the existing transaction schema: `mint_pr` stores the payment request and `mint_hash` stores the quote identifier.

Stored claims are checked with both current and pre-v1 identifiers so the v1 state response does not incorrectly classify an existing proof. Each claim is still included at most once in the token and withdrawal amount.

## Impact

Newly settled payments use the v1 quote and mint flow. Claim responses include only explicitly unspent proofs, and pending or spent proofs are not recorded in the withdrawal or included in its count.

## Validation

- `npm ci --ignore-scripts --no-audit --no-fund`
- `npm test -- --reporter=dot` — 42 tests passed
- `npm run build` — frontend and server production builds passed
- clean resolution confirmed backend `cashu-ts@1.0.0` and website workspace `cashu-ts@1.1.0`

## Known pre-existing issue

A standalone root `tsc` invocation still reports the existing `src/utils/blink.ts:151` response-type error. The production build passes and this change does not modify that code.
