### PR TITLE
Fix Primal zap request compatibility

### DIFF
--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -15,6 +15,7 @@ import { PerMintRequestBudget } from "./infrastructure/MintRequestBudget";
 import { config } from "./config/index";
 import { logger } from "./utils/logger";
 import { handleZapRequest } from "./utils/nostr";
+import { decodeZapRequestParameter } from "./utils/zapRequest";
 import {
   createRecipientBlocks,
   RecipientBlocks,
@@ -57,7 +58,7 @@ export async function initializeAppServices(
       eventBus.emit("quotePaid", quote);
       if (!quote.serializedZapRequest || !config.nostr.nostrEnabled) return;
       try {
-        const zapRequest = JSON.parse(quote.serializedZapRequest);
+        const zapRequest = decodeZapRequestParameter(quote.serializedZapRequest);
         await handleZapRequest(
           quote.quoteId,
           zapRequest,

--- a/packages/server/src/utils/nostr.ts
+++ b/packages/server/src/utils/nostr.ts
@@ -12,8 +12,6 @@ import { config } from "../config/index";
 import { Logger } from "winston";
 import { decodeZapRequestParameter } from "./zapRequest";
 
-export { decodeZapRequestParameter } from "./zapRequest";
-
 export function getTagValues(e: Event, tag: string, position: number) {
   const tags = e.tags;
   const values: string[] = [];

--- a/packages/server/src/utils/nostr.ts
+++ b/packages/server/src/utils/nostr.ts
@@ -10,6 +10,9 @@ import { ZapRequestData } from "../types";
 import { nostrPool } from "../config";
 import { config } from "../config/index";
 import { Logger } from "winston";
+import { decodeZapRequestParameter } from "./zapRequest";
+
+export { decodeZapRequestParameter } from "./zapRequest";
 
 export function getTagValues(e: Event, tag: string, position: number) {
   const tags = e.tags;
@@ -84,7 +87,7 @@ export function decodeAndValidateZapRequest(
   encodedZapRequest: string,
   lnurlAmount: string,
 ) {
-  const decodedEvent = JSON.parse(decodeURI(encodedZapRequest)) as Event;
+  const decodedEvent = decodeZapRequestParameter(encodedZapRequest);
   validateEvent(decodedEvent);
   const zapRequestData = extractZapRequestData(decodedEvent);
   const isValidData = isValidZapRequestData(
@@ -107,10 +110,6 @@ export function isValidZapRequestData(z: ZapRequestData, lnurlAmount: number) {
     }
   }
   return true;
-}
-
-export function decodeZapRequestParameter(r: string) {
-  return JSON.parse(decodeURI(r)) as Event;
 }
 
 const createTimeoutPromise = (ms: number) => {

--- a/packages/server/src/utils/zapRequest.test.ts
+++ b/packages/server/src/utils/zapRequest.test.ts
@@ -1,0 +1,67 @@
+import { expect, test } from "bun:test";
+import express from "express";
+import { finalizeEvent, nip57 } from "nostr-tools";
+import { decodeZapRequestParameter } from "./zapRequest";
+
+const amount = 21_000;
+
+function createZapRequest(content: string) {
+  const request = nip57.makeZapRequest({
+    pubkey: "02".repeat(32),
+    amount,
+    relays: ["wss://relay.example.com"],
+    comment: content,
+  });
+  return finalizeEvent(request, new Uint8Array(32).fill(1));
+}
+
+test("decodes a standards-compliant framework-decoded zap request", () => {
+  const event = createZapRequest("100% compatible, with a literal %20");
+
+  const decoded = decodeZapRequestParameter(JSON.stringify(event));
+
+  expect(decoded.id).toBe(event.id);
+  expect(decoded.content).toBe("100% compatible, with a literal %20");
+});
+
+test("accepts Primal's double-encoded zap request after query parsing", () => {
+  const event = createZapRequest("Zap!");
+  const callback = new URL("https://npub.cash/.well-known/lnurlp/example");
+  callback.searchParams.set("amount", String(amount));
+  callback.searchParams.set(
+    "nostr",
+    encodeURIComponent(JSON.stringify(event)),
+  );
+
+  const receivedNostrParameter = new URL(callback).searchParams.get("nostr")!;
+  const decoded = decodeZapRequestParameter(receivedNostrParameter);
+
+  expect(decoded.id).toBe(event.id);
+  expect(decoded.content).toBe("Zap!");
+});
+
+test("handles standard and Primal query values after Express parsing", () => {
+  const app = express();
+  const parseQuery = app.get("query parser fn") as (
+    query: string,
+  ) => Record<string, unknown>;
+  const event = createZapRequest("Express integration");
+  const serializedEvent = JSON.stringify(event);
+
+  const standardUrl = new URL("https://npub.cash/callback");
+  standardUrl.searchParams.set("nostr", serializedEvent);
+  const standardValue = parseQuery(standardUrl.search.slice(1)).nostr;
+
+  expect(standardValue).toBe(serializedEvent);
+  expect(decodeZapRequestParameter(standardValue as string).id).toBe(event.id);
+
+  const primalValue = encodeURIComponent(serializedEvent);
+  const primalUrl = new URL("https://npub.cash/callback");
+  primalUrl.searchParams.set("nostr", primalValue);
+  const parsedPrimalValue = parseQuery(primalUrl.search.slice(1)).nostr;
+
+  expect(parsedPrimalValue).toBe(primalValue);
+  expect(decodeZapRequestParameter(parsedPrimalValue as string).id).toBe(
+    event.id,
+  );
+});

--- a/packages/server/src/utils/zapRequest.ts
+++ b/packages/server/src/utils/zapRequest.ts
@@ -1,0 +1,12 @@
+import type { Event } from "nostr-tools";
+
+export function decodeZapRequestParameter(value: string): Event {
+  try {
+    return JSON.parse(value) as Event;
+  } catch {
+    // Query parsers already decode standards-compliant parameter values. Some
+    // clients, including Primal, encode the JSON before passing it to
+    // URLSearchParams and therefore leave one extra encoding layer behind.
+    return JSON.parse(decodeURIComponent(value)) as Event;
+  }
+}


### PR DESCRIPTION
## Summary

- parse standards-compliant zap request query values after Express has decoded them
- accept Primal's currently double-encoded `nostr` parameter with a one-layer compatibility fallback
- reuse the compatibility decoder when processing paid quotes so zap receipts are still published
- add regression coverage against the query parser configured by Express

## Root cause

Primal URI-encodes the signed event before passing it to `URLSearchParams`, which encodes the value again. Express removes the outer layer, leaving one percent-encoded layer. npub.cash previously used `decodeURI`, which preserves reserved escapes such as `%3A` and `%2C`, causing `JSON.parse` to reject the request.

The new parser first accepts the framework-decoded JSON directly, preserving literal percent text in comments, and falls back to one `decodeURIComponent` pass for affected clients.

## Impact

npub.cash can issue invoices and later publish zap receipts for both NIP-57-compatible clients and current Primal web clients.

## Validation

- `bun test src/utils/zapRequest.test.ts src/controller/lnurlController.test.ts` — 7 passed
- `bun run build` — passed

## Existing unrelated failures

The full server suite currently has three pre-existing `usernameController` mock failures. A standalone TypeScript check also has an existing unresolved `@npubcash/types` import in `wallet.ts`.
